### PR TITLE
Back-tick version to 1.1.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "cchardet" %}
-{% set version = "2.1.0" %}
+{% set version = "1.1.3" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "3d77f9ea11f12f1a4e0413f79f0876b7b10ff065b03bad4860a453b696856fcf" %}
+{% set hash = "b4ccd55b0e917d98fa94aee19b7551e9d38d0835b608ebe843f72b48587e6b74" %}
 {% set build = 0 %}
 
 package:


### PR DESCRIPTION
Create a `1.1.3` version of `cchardet` for use with `tabulator`